### PR TITLE
fix: gh-pages build: drop the ref while trigger from Run Data Sync (#…

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -47,6 +47,9 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
+        with:
+          # if your default branches is not master, please change it here
+          ref: master
 
       - name: Cache Data Files
         if: inputs.save_data_in_github_cache


### PR DESCRIPTION
…540)

* fix: gh-pages build: drop the ref while trigger from Run Data Sync