### PR TITLE
fix: Enable persist-credentials to resolve authentication failure in …

### DIFF
--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -1,7 +1,7 @@
-name: Run Data Sync
+﻿name: Run Data Sync
 
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
   push:
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Set up Python
         id: setup_python


### PR DESCRIPTION
…GitHub Actions (#780)

* ci: 更新 GitHub Actions 工作流配置

- 修改了 actions/checkout@v4 步骤的 persist-credentials 参数
- 将 persist-credentials 参数从 false 修改为 true

* ci: 更新 GitHub Actions 工作流中的凭据配置

- 在 ci.yml 中将 persist-credentials 设置为 false，以提高安全性
- 在 run_data_sync.yml 中将 persist-credentials 设置为 true，以确保数据同步任务的正常运行